### PR TITLE
feat : User 도메인 API 구현

### DIFF
--- a/src/main/java/com/hansarangdelivery/config/WebSecurityConfig.java
+++ b/src/main/java/com/hansarangdelivery/config/WebSecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -21,6 +22,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(securedEnabled = true)
 public class WebSecurityConfig {
 
     private final JwtUtil jwtUtil;

--- a/src/main/java/com/hansarangdelivery/controller/UserController.java
+++ b/src/main/java/com/hansarangdelivery/controller/UserController.java
@@ -1,15 +1,15 @@
 package com.hansarangdelivery.controller;
 
-import com.hansarangdelivery.dto.ResultResponseDto;
-import com.hansarangdelivery.dto.SignupRequestDto;
+import com.hansarangdelivery.dto.*;
+import com.hansarangdelivery.security.UserDetailsImpl;
 import com.hansarangdelivery.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,8 +19,50 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<ResultResponseDto> SignUp(@Valid @RequestBody SignupRequestDto requestDto) {
+    public ResponseEntity<ResultResponseDto<Void>> SignUp(@Valid @RequestBody SignupRequestDto requestDto) {
         userService.signup(requestDto);
-        return ResponseEntity.status(200).body(new ResultResponseDto("회원가입 성공", 200));
+        return ResponseEntity.status(200).body(new ResultResponseDto<>("회원가입 성공", 200));
     }
+
+    @GetMapping("/{userId}")
+    @PreAuthorize("hasRole('ROLE_MANAGER')")
+    public ResponseEntity<ResultResponseDto<UserResponseDto>> getProfile(@PathVariable("userId") Long userId) {
+        UserResponseDto responseDto = userService.getProfile(userId);
+        return ResponseEntity.status(200).body(new ResultResponseDto<>("조회 성공", 200, responseDto));
+    }
+
+    @GetMapping()
+    @PreAuthorize("hasRole('ROLE_MANAGER')")
+    public ResponseEntity<ResultResponseDto<Page<UserResponseDto>>> getAllProfile(@RequestBody PageRequestDto requestDto) {
+        Page<UserResponseDto> responseDtoPage = userService.getAllProfile(requestDto);
+        return ResponseEntity.status(200).body(new ResultResponseDto<>("조회 성공",200, responseDtoPage));
+    }
+
+    @GetMapping("/my-profile")
+    public ResponseEntity<ResultResponseDto<UserResponseDto>> getMyProfile(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        UserResponseDto responseDto = new UserResponseDto(userDetails.getUser());
+        return ResponseEntity.status(200).body(new ResultResponseDto<>("조회 성공", 200, responseDto));
+    }
+
+    @PutMapping("/my-profile")
+    public ResponseEntity<ResultResponseDto<Void>> updateProfile(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                 @RequestBody UserUpdateDto requestDto) {
+        userService.updateProfile(userDetails.getUser().getId(), requestDto);
+        return ResponseEntity.status(200).body(new ResultResponseDto<>("회원 정보 수정 성공", 200));
+    }
+
+    @PutMapping("/{userId}")
+    @PreAuthorize("hasRole('ROLE_MASTER')")
+    public ResponseEntity<ResultResponseDto<Void>> updateRole(@PathVariable("userId")Long userId) {
+        userService.updateRole(userId);
+        return ResponseEntity.status(200).body(new ResultResponseDto<>("권한 변경 성공", 200));
+    }
+
+    @DeleteMapping()
+    public ResponseEntity<ResultResponseDto<Void>> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                              @RequestParam(value = "userId", required = false) Long userId) {
+        userService.deleteUser(userDetails.getUser(), userId);
+        return ResponseEntity.status(200).body(new ResultResponseDto<>("회원 탈퇴 성공", 200));
+    }
+
 }

--- a/src/main/java/com/hansarangdelivery/dto/PageRequestDto.java
+++ b/src/main/java/com/hansarangdelivery/dto/PageRequestDto.java
@@ -1,0 +1,10 @@
+package com.hansarangdelivery.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PageRequestDto {
+    private int page;
+    private int size;
+    private boolean isAsc;
+}

--- a/src/main/java/com/hansarangdelivery/dto/ResultResponseDto.java
+++ b/src/main/java/com/hansarangdelivery/dto/ResultResponseDto.java
@@ -1,16 +1,18 @@
 package com.hansarangdelivery.dto;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
-public class ResultResponseDto {
+@AllArgsConstructor
+public class ResultResponseDto<D> {
     private String message;
     private int statusCode;
+    private D data;
 
     public ResultResponseDto(String message, int statusCode){
         this.message = message;
         this.statusCode = statusCode;
+        this.data = null;
     }
 }

--- a/src/main/java/com/hansarangdelivery/dto/UserResponseDto.java
+++ b/src/main/java/com/hansarangdelivery/dto/UserResponseDto.java
@@ -1,0 +1,20 @@
+package com.hansarangdelivery.dto;
+
+import com.hansarangdelivery.entity.User;
+import com.hansarangdelivery.entity.UserRole;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserResponseDto {
+    private String username;
+    private String email;
+    private UserRole role;
+
+    public UserResponseDto(User user) {
+        this.username = user.getUsername();
+        this.email = user.getEmail();
+        this.role = user.getRole();
+    }
+}

--- a/src/main/java/com/hansarangdelivery/dto/UserUpdateDto.java
+++ b/src/main/java/com/hansarangdelivery/dto/UserUpdateDto.java
@@ -1,0 +1,11 @@
+package com.hansarangdelivery.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserUpdateDto {
+    private String username;
+    private String email;
+}

--- a/src/main/java/com/hansarangdelivery/entity/DeliveryLocation.java
+++ b/src/main/java/com/hansarangdelivery/entity/DeliveryLocation.java
@@ -1,0 +1,32 @@
+package com.hansarangdelivery.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "p_delivery_location")
+public class DeliveryLocation extends TimeStamped {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false)
+    private UUID id;
+
+    @Column(nullable = false)
+    private Long locationCode;
+
+    @Column(nullable = false, length = 100)
+    private String location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/hansarangdelivery/entity/User.java
+++ b/src/main/java/com/hansarangdelivery/entity/User.java
@@ -6,6 +6,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -27,12 +30,25 @@ public class User extends TimeStamped{
     private String email;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private UserRole role;  // CUSTOMER, OWNER, MANAGER, MASTER
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DeliveryLocation> deliveries = new ArrayList<>();
 
     public User(String username, String password, String email, UserRole role) {
         this.username = username;
         this.password = password;
         this.email = email;
         this.role = role;
+    }
+
+    public void updateProfile(String username, String email) {
+        this.username = username;
+        this.email = email;
+    }
+
+    public void updateRole() {
+        this.role = UserRole.MANAGER;
     }
 }

--- a/src/main/java/com/hansarangdelivery/repository/UserRepositoryQueryImpl.java
+++ b/src/main/java/com/hansarangdelivery/repository/UserRepositoryQueryImpl.java
@@ -1,0 +1,42 @@
+package com.hansarangdelivery.repository;
+
+import com.hansarangdelivery.entity.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.hansarangdelivery.entity.QUser.user;
+
+@Repository
+public class UserRepositoryQueryImpl {
+    @PersistenceContext
+    private EntityManager em;
+
+    private final JPAQueryFactory qf;
+
+    public UserRepositoryQueryImpl(EntityManager em) {
+        this.qf = new JPAQueryFactory(em);
+    }
+
+    public Page<User> searchUsers(Pageable pageable) {
+        List<User> content = qf
+            .selectFrom(user)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(pageable.getSort().stream()
+                .map(order -> order.isAscending() ? user.createdAt.asc() : user.createdAt.desc())
+                .findFirst()
+                .orElse(user.createdAt.desc()))
+            .fetch();
+
+        long total = qf.selectFrom(user).fetch().size();
+
+        return PageableExecutionUtils.getPage(content, pageable, () -> total);
+    }
+}

--- a/src/main/java/com/hansarangdelivery/service/UserService.java
+++ b/src/main/java/com/hansarangdelivery/service/UserService.java
@@ -1,25 +1,95 @@
 package com.hansarangdelivery.service;
 
+import com.hansarangdelivery.dto.PageRequestDto;
 import com.hansarangdelivery.dto.SignupRequestDto;
+import com.hansarangdelivery.dto.UserResponseDto;
+import com.hansarangdelivery.dto.UserUpdateDto;
 import com.hansarangdelivery.entity.User;
 import com.hansarangdelivery.entity.UserRole;
 import com.hansarangdelivery.repository.UserRepository;
+import com.hansarangdelivery.repository.UserRepositoryQueryImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserRepositoryQueryImpl userRepositoryQuery;
     private final PasswordEncoder passwordEncoder;
+
     public void signup(SignupRequestDto requestDto) {
         String username = requestDto.getUsername();
         String password = passwordEncoder.encode(requestDto.getPassword());
         String email = requestDto.getEmail();
         UserRole role = requestDto.getRole();
 
+        validateInfo(username, email);
+
+        // 사용자 등록
+        User user = new User(username, password, email, role);
+        userRepository.save(user);
+    }
+
+    public UserResponseDto getProfile(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(
+            () -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        return new UserResponseDto(user);
+    }
+
+    public Page<UserResponseDto> getAllProfile(PageRequestDto requestDto) {
+        int page = requestDto.getPage()-1; // 0부터 시작하도록
+        int size = requestDto.getSize();
+        boolean isAsc = requestDto.isAsc();
+
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, "createdAt");
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        return userRepositoryQuery.searchUsers(pageable).map(UserResponseDto::new);
+    }
+
+    @Transactional
+    public void updateProfile(Long userId, UserUpdateDto requestDto) {
+        User user = findUser(userId);
+
+        String username = requestDto.getUsername();
+        String email = requestDto.getEmail();
+
+        validateInfo(username, email);
+
+        user.updateProfile(username, email);
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void updateRole(Long userId) {
+        User user = findUser(userId);
+
+        user.updateRole();
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void deleteUser(User currentUser, Long userId) {
+        if (userId == null) {
+            userRepository.deleteById(currentUser.getId());
+        } else {
+            if (currentUser.getRole() != UserRole.MASTER) {
+                throw new IllegalArgumentException("권한이 없습니다.");
+            }
+            userRepository.deleteById(userId);
+        }
+    }
+
+    private void validateInfo(String username, String email) {
         // 회원 중복 확인
         if (userRepository.existsByUsername(username)) {
             throw new IllegalArgumentException("중복된 사용자가 존재합니다.");
@@ -29,9 +99,10 @@ public class UserService {
         if (userRepository.existsByEmail(email)) {
             throw new IllegalArgumentException("중복된 Email 입니다.");
         }
+    }
 
-        // 사용자 등록
-        User user = new User(username, password, email, role);
-        userRepository.save(user);
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,4 +7,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
 jwt.secret.key=${JWT_SECRET_KEY}


### PR DESCRIPTION
## 📝 작업내용
- feat : 자신 정보 조회, 특정 회원 조회 API 구현
- feat : 자신 회원 정보 수정, 특정 유저 권한 수정(->MANAGER) API 구현
- feat : 회원 탈퇴 API 구현
- feat : QueryDSL 적용, 모든 회원 정보 조회(페이징) API 구현
- feat : 배송지 엔티티 생성 및 User와 연관관계 설정
- fix : UserRole String 타입으로 변경

<br>

## ✨ 변경 사항
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
<br>

## To Reviewrs 🙏
- 정신 없이 기능 구현하다가 중간 중간 커밋 남기는걸 깜박했습니다 ㅠㅠ 죄송합니다.
- UserRole이 DB에 smallInt로 저장되길래 String 타입으로 변경했습니다.
- 회원 가입 시 role 관련 보안 설정을 추가할 생각입니다 (MASTER로 회원가입하려면 어드민 코드를 입력받는다던가?) 좋은 아이디어 있으시면 의견 부탁드립니다!
- 배송지는 현재 엔티티만 만들어놓은 상태인데, 관련 로직은 곧 추가하겠습니다
- 마음에 안드시는 부분이 있거나, 보완이 필요한 부분이 있다면 가감없이 피드백 부탁드립니다! 내일(토요일) 확인하고 수정하겠습니다.
