### PR TITLE
Payment 엔티티 생성, Mock Payment 생성 메서드 구현

### DIFF
--- a/src/main/java/com/hansarangdelivery/entity/Payment.java
+++ b/src/main/java/com/hansarangdelivery/entity/Payment.java
@@ -1,0 +1,39 @@
+package com.hansarangdelivery.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Payment extends TimeStamped{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false)
+    private UUID id;
+
+    @Column(nullable = false)
+    private Long orderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentMethod paymentMethod; // 결제 방법 (카드, 간편결제 등)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus paymentStatus; // 결제 상태
+
+    @Column(nullable = false)
+    private int totalPrice; // 결제 금액
+
+    @Column(unique = true)
+    private String transactionId; // 결제 시스템의 거래 ID (Mock 데이터)
+}

--- a/src/main/java/com/hansarangdelivery/entity/PaymentMethod.java
+++ b/src/main/java/com/hansarangdelivery/entity/PaymentMethod.java
@@ -1,0 +1,5 @@
+package com.hansarangdelivery.entity;
+
+public enum PaymentMethod {
+    CARD, KAKAO_PAY, NAVER_PAY, APPLE_PAY, PAYPAL
+}

--- a/src/main/java/com/hansarangdelivery/entity/PaymentStatus.java
+++ b/src/main/java/com/hansarangdelivery/entity/PaymentStatus.java
@@ -1,0 +1,5 @@
+package com.hansarangdelivery.entity;
+
+public enum PaymentStatus {
+    PENDING, COMPLETED, FAILED, CANCELLED
+}

--- a/src/main/java/com/hansarangdelivery/repository/PaymentRepository.java
+++ b/src/main/java/com/hansarangdelivery/repository/PaymentRepository.java
@@ -1,0 +1,9 @@
+package com.hansarangdelivery.repository;
+
+import com.hansarangdelivery.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PaymentRepository extends JpaRepository<Payment, UUID> {
+}

--- a/src/main/java/com/hansarangdelivery/service/PaymentService.java
+++ b/src/main/java/com/hansarangdelivery/service/PaymentService.java
@@ -1,0 +1,28 @@
+package com.hansarangdelivery.service;
+
+import com.hansarangdelivery.entity.Payment;
+import com.hansarangdelivery.entity.PaymentMethod;
+import com.hansarangdelivery.entity.PaymentStatus;
+import com.hansarangdelivery.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    public void createMockPayment(Long orderId, int totalPrice) {
+        Payment payment = new Payment();
+        payment.setOrderId(orderId);
+        payment.setTotalPrice(totalPrice);
+        payment.setPaymentMethod(PaymentMethod.KAKAO_PAY); // 일단 KAKAO_PAY를 디폴트로 설정
+        payment.setPaymentStatus(PaymentStatus.PENDING); // 이것도 일단 디폴트로..
+        payment.setTransactionId(UUID.randomUUID().toString()); // 랜덤 UUID 설정
+
+        paymentRepository.save(payment);
+    }
+}


### PR DESCRIPTION
## 📝 작업내용
- Payment 엔티티 생성
- Mock Payment를 생성하는 메서드 구현

<br>

## ✨ 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
<br>

## To Reviewrs 🙏
- Payment 엔티티에는 결제에 필요할만한 데이터들을 구상해서 넣어봤습니다.
- Payment 도메인은 엔드 포인트를 생성하지 않을 것이고 필요한 기능도 하나밖에 없어서(Mock 데이터 생성) 해당 메서드를 어디에 둘지 고민을 해봤는데 추후 확장성을 고려해서 PaymentService 클래스를 만든 뒤 거기에 위치시켰습니다.
- Order를 생성할 때 활용해주시면 될 것 같습니다
