### PR TITLE
Ai Response 도메인 API 구현

### DIFF
--- a/src/main/java/com/hansarangdelivery/config/RestTemplateConfig.java
+++ b/src/main/java/com/hansarangdelivery/config/RestTemplateConfig.java
@@ -1,0 +1,23 @@
+package com.hansarangdelivery.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+
+        // 무한 대기를 방지하기 위한 타임아웃 설정
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);  // 연결 타임아웃
+        factory.setReadTimeout(5000);     // 읽기 타임아웃
+
+        return builder
+            .requestFactory(() -> factory)
+            .build();
+    }
+}

--- a/src/main/java/com/hansarangdelivery/controller/AiResponseController.java
+++ b/src/main/java/com/hansarangdelivery/controller/AiResponseController.java
@@ -20,6 +20,7 @@ public class AiResponseController {
 
     private final AiResponseService aiResponseService;
 
+    // AI 응답 생성 API
     @PostMapping()
     @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MANAGER')")
     public ResultResponseDto<String> createAiResponse(@AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -28,6 +29,7 @@ public class AiResponseController {
         return new ResultResponseDto<>("Ai 응답 생성 성공", 200, response);
     }
 
+    // AI 응답 단건 조회 API (Permission : 본인이 생성한 응답이거나 권한이 MANAGER 인 경우)
     @GetMapping("/{aiResponseId}")
     public ResultResponseDto<AiResponseDto> getAiResponse(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                           @PathVariable("aiResponseId") UUID aiResponseId) {
@@ -35,6 +37,7 @@ public class AiResponseController {
         return new ResultResponseDto<>("조회 성공", 200, aiResponseDto);
     }
 
+    // 본인이 생성한 AI 응답 전체 조회 API
     @GetMapping()
     public ResultResponseDto<Page<AiResponseDto>> searchAiResponses(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                     @RequestParam("page") int page,
@@ -44,6 +47,7 @@ public class AiResponseController {
         return new ResultResponseDto<>("조회 성공", 200, aiResponseDtos);
     }
 
+    // AI 응답 삭제 API (Permission : 본인이 생성한 응답이거나 권한이 MANAGER 인 경우)
     @DeleteMapping("/{aiResponseId}")
     public ResultResponseDto<Void> deleteAiResponse(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                     @PathVariable("aiResponseId") UUID aiResponseId) {

--- a/src/main/java/com/hansarangdelivery/controller/AiResponseController.java
+++ b/src/main/java/com/hansarangdelivery/controller/AiResponseController.java
@@ -1,16 +1,17 @@
 package com.hansarangdelivery.controller;
 
 import com.hansarangdelivery.dto.AiRequestDto;
+import com.hansarangdelivery.dto.AiResponseDto;
 import com.hansarangdelivery.dto.ResultResponseDto;
 import com.hansarangdelivery.security.UserDetailsImpl;
 import com.hansarangdelivery.service.AiResponseService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +26,21 @@ public class AiResponseController {
                                                       @RequestBody AiRequestDto requestDto) {
         String response = aiResponseService.createAiResponse(userDetails.getUser().getId(), requestDto);
         return new ResultResponseDto<>("Ai 응답 생성 성공", 200, response);
+    }
+
+    @GetMapping("/{aiResponseId}")
+    public ResultResponseDto<AiResponseDto> getAiResponse(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                          @PathVariable("aiResponseId") UUID aiResponseId) {
+        AiResponseDto aiResponseDto = aiResponseService.getAiResponse(userDetails.getUser(), aiResponseId);
+        return new ResultResponseDto<>("조회 성공", 200, aiResponseDto);
+    }
+
+    @GetMapping()
+    public ResultResponseDto<Page<AiResponseDto>> searchAiResponses(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                    @RequestParam("page") int page,
+                                                                    @RequestParam("size") int size,
+                                                                    @RequestParam("isAsc") boolean isAsc) {
+        Page<AiResponseDto> aiResponseDtos = aiResponseService.searchAiResponses(userDetails.getUser(), page, size, isAsc);
+        return new ResultResponseDto<>("조회 성공", 200, aiResponseDtos);
     }
 }

--- a/src/main/java/com/hansarangdelivery/controller/AiResponseController.java
+++ b/src/main/java/com/hansarangdelivery/controller/AiResponseController.java
@@ -43,4 +43,11 @@ public class AiResponseController {
         Page<AiResponseDto> aiResponseDtos = aiResponseService.searchAiResponses(userDetails.getUser(), page, size, isAsc);
         return new ResultResponseDto<>("조회 성공", 200, aiResponseDtos);
     }
+
+    @DeleteMapping("/{aiResponseId}")
+    public ResultResponseDto<Void> deleteAiResponse(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                    @PathVariable("aiResponseId") UUID aiResponseId) {
+        aiResponseService.deleteAiResponse(userDetails.getUser(), aiResponseId);
+        return new ResultResponseDto<>("삭제 성공", 200);
+    }
 }

--- a/src/main/java/com/hansarangdelivery/controller/AiResponseController.java
+++ b/src/main/java/com/hansarangdelivery/controller/AiResponseController.java
@@ -1,0 +1,29 @@
+package com.hansarangdelivery.controller;
+
+import com.hansarangdelivery.dto.AiRequestDto;
+import com.hansarangdelivery.dto.ResultResponseDto;
+import com.hansarangdelivery.security.UserDetailsImpl;
+import com.hansarangdelivery.service.AiResponseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ai")
+public class AiResponseController {
+
+    private final AiResponseService aiResponseService;
+
+    @PostMapping()
+    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MANAGER')")
+    public ResultResponseDto<String> createAiResponse(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                      @RequestBody AiRequestDto requestDto) {
+        String response = aiResponseService.createAiResponse(userDetails.getUser().getId(), requestDto);
+        return new ResultResponseDto<>("Ai 응답 생성 성공", 200, response);
+    }
+}

--- a/src/main/java/com/hansarangdelivery/controller/AiResponseController.java
+++ b/src/main/java/com/hansarangdelivery/controller/AiResponseController.java
@@ -43,7 +43,7 @@ public class AiResponseController {
                                                                     @RequestParam("page") int page,
                                                                     @RequestParam("size") int size,
                                                                     @RequestParam("isAsc") boolean isAsc) {
-        Page<AiResponseDto> aiResponseDtos = aiResponseService.searchAiResponses(userDetails.getUser(), page, size, isAsc);
+        Page<AiResponseDto> aiResponseDtos = aiResponseService.searchAiResponses(userDetails.getUser(), page-1, size, isAsc);
         return new ResultResponseDto<>("조회 성공", 200, aiResponseDtos);
     }
 

--- a/src/main/java/com/hansarangdelivery/controller/ReviewController.java
+++ b/src/main/java/com/hansarangdelivery/controller/ReviewController.java
@@ -4,8 +4,10 @@ import com.hansarangdelivery.dto.ResultResponseDto;
 import com.hansarangdelivery.dto.ReviewRequestDto;
 import com.hansarangdelivery.service.ReviewService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
@@ -18,7 +20,4 @@ public class ReviewController {
     public ResultResponseDto<Void> addReview(@RequestBody ReviewRequestDto requestDto) {
         return reviewService.addReview(requestDto);
     }
-
-    @GetMapping
-    public ResultResponseDto<List<ReviewResponseDto>>
 }

--- a/src/main/java/com/hansarangdelivery/dto/AiApiResponseDto.java
+++ b/src/main/java/com/hansarangdelivery/dto/AiApiResponseDto.java
@@ -1,0 +1,32 @@
+package com.hansarangdelivery.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AiApiResponseDto {
+
+    private List<Candidate> candidates;
+
+    @Getter
+    public static class Candidate {
+        private Content content;
+    }
+
+    @Getter
+    public static class Content {
+        private List<Part> parts;
+    }
+
+    @Getter
+    public static class Part {
+        private String text;
+    }
+}

--- a/src/main/java/com/hansarangdelivery/dto/AiRequestDto.java
+++ b/src/main/java/com/hansarangdelivery/dto/AiRequestDto.java
@@ -1,0 +1,14 @@
+package com.hansarangdelivery.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiRequestDto {
+    private String request;
+}

--- a/src/main/java/com/hansarangdelivery/dto/AiResponseDto.java
+++ b/src/main/java/com/hansarangdelivery/dto/AiResponseDto.java
@@ -1,0 +1,19 @@
+package com.hansarangdelivery.dto;
+
+import com.hansarangdelivery.entity.AiResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AiResponseDto {
+    private String request;
+    private String response;
+
+    public AiResponseDto(AiResponse aiResponse) {
+        this.request = aiResponse.getRequest();
+        this.response = aiResponse.getResponse();
+    }
+}

--- a/src/main/java/com/hansarangdelivery/entity/AiResponse.java
+++ b/src/main/java/com/hansarangdelivery/entity/AiResponse.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,19 +17,28 @@ import lombok.Setter;
 @Entity
 @Table(name = "p_ai_response")
 @NoArgsConstructor
-public class AI_response extends TimeStamped{
-    // 명확한 작동 방식을 생각하며 넣은게 아니라서 다 갈아엎어도 됩니다.
+@AllArgsConstructor
+public class AiResponse extends TimeStamped{
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "id", columnDefinition = "uuid", updatable = false, nullable = false)
     private UUID id; // 고유 식별자
 
-    @Column(name = "request_text", columnDefinition = "TEXT", nullable = false)
-    private String request_text; // 요청 텍스트?
+    @Column(nullable = false)
+    private Long userId;
 
-    @Column(name = "response_text", columnDefinition = "TEXT")
-    private String response_text; // AI의 답변 텍스트?
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String request;
 
+    @Column(columnDefinition = "TEXT")
+    private String response;
+
+    public AiResponse(Long userId, String request, String response) {
+        this.userId = userId;
+        this.request = request;
+        this.response = response;
+    }
 }
 
 

--- a/src/main/java/com/hansarangdelivery/entity/Review.java
+++ b/src/main/java/com/hansarangdelivery/entity/Review.java
@@ -20,7 +20,7 @@ public class Review extends TimeStamped {
     private UUID id;
 
     @Column(nullable = false, unique = true, updatable = false)
-    private UUID order_id;
+    private UUID orderId;
 
     @Column(nullable = false)
     private String content;
@@ -29,7 +29,7 @@ public class Review extends TimeStamped {
     private int rating;
 
     public Review(UUID orderId, String content, int rating) {
-        this.order_id = orderId;
+        this.orderId = orderId;
         this.content = content;
         this.rating = rating;
     }

--- a/src/main/java/com/hansarangdelivery/repository/AiResponseRepository.java
+++ b/src/main/java/com/hansarangdelivery/repository/AiResponseRepository.java
@@ -1,9 +1,12 @@
 package com.hansarangdelivery.repository;
 
 import com.hansarangdelivery.entity.AiResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface AiResponseRepository extends JpaRepository<AiResponse, UUID> {
+    Page<AiResponse> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/hansarangdelivery/repository/AiResponseRepository.java
+++ b/src/main/java/com/hansarangdelivery/repository/AiResponseRepository.java
@@ -1,0 +1,9 @@
+package com.hansarangdelivery.repository;
+
+import com.hansarangdelivery.entity.AiResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface AiResponseRepository extends JpaRepository<AiResponse, UUID> {
+}

--- a/src/main/java/com/hansarangdelivery/service/AiResponseService.java
+++ b/src/main/java/com/hansarangdelivery/service/AiResponseService.java
@@ -1,0 +1,79 @@
+package com.hansarangdelivery.service;
+
+import com.hansarangdelivery.dto.AiRequestDto;
+import com.hansarangdelivery.dto.AiApiResponseDto;
+import com.hansarangdelivery.entity.AiResponse;
+import com.hansarangdelivery.repository.AiResponseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AiResponseService {
+
+    private final AiResponseRepository aiResponseRepository;
+    private final RestTemplate restTemplate;
+
+    @Value("${google.ai.api.key}")
+    private String apiKey;
+
+    @Value("${google.ai.api.url}")
+    private String apiUrl;
+
+
+    public String createAiResponse(Long userId, AiRequestDto requestDto) {
+
+        // Google Ai Studio의 리퀘스트 형식에 맞게 데이터 변환
+        Map<String, Object> requestBody = setRequest(requestDto.getRequest());
+
+        // HTTP 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // Request 객체 생성
+        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(requestBody, headers);
+
+        ResponseEntity<AiApiResponseDto> responseEntity = restTemplate.exchange(
+            apiUrl + apiKey,
+            HttpMethod.POST,
+            requestEntity,
+            AiApiResponseDto.class
+        );
+
+        AiApiResponseDto responseDto = responseEntity.getBody();
+
+        // Google Ai Studio의 응답에서 필요한 데이터(Ai 답변)만 추출
+        String response = extractResponseText(responseDto);
+
+        AiResponse airesponse = new AiResponse(userId, requestDto.getRequest(), response);
+        aiResponseRepository.save(airesponse);
+
+        return response;
+    }
+
+    private Map<String, Object> setRequest(String requestText) {
+        requestText += " 답변을 최대한 간결하게 50자 이하로";
+        return Map.of(
+            "contents", Collections.singletonList(
+                Map.of("parts", Collections.singletonList(
+                    Map.of("text", requestText)
+                ))
+            )
+        );
+    }
+
+    private String extractResponseText(AiApiResponseDto responseDto) {
+        return responseDto.getCandidates()
+            .get(0)
+            .getContent()
+            .getParts()
+            .get(0)
+            .getText();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,6 @@ spring.jpa.properties.hibernate.format_sql=true
 jwt.secret.key=${JWT_SECRET_KEY}
 
 admin.code=123456
+
+google.ai.api.key=${GOOGLE_AI_STUDIO_API_KEY}
+google.ai.api.url=https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=


### PR DESCRIPTION
## 📝 작업내용
- refactor : AiResponse 엔티티 수정
- feat : Ai 응답 생성, 단건 조회, 전체 조회(본인이 생성한 Ai응답), 삭제 API 구현

<br>

## ✨ 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
<br>

## To Reviewrs 🙏
- application.properties에 구글 ai 스튜디오 API 키를 환경변수로 등록해야 합니다. 키는 슬랙에 올려두겠습니다
- 전체 조회 API는 페이징 처리를 하였는데, 정렬 기준은 User 도메인과 마찬가지로 createAt(생성일)을 디폴트로 설정했습니다. 사실 이거 말고는 정렬 기준으로 쓸 필드 변수가 없습니다
- AI 자동 응답이 담기는 AI Response를 수정하는 기능은 사실상 필요 없을 것 같아서 Update API는 따로 구현하지 않았습니다. 필요해진다면 추후 추가하겠습니다.
